### PR TITLE
Fix README.md install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can clone this repo and simply execute:
 ```bash
 $ git clone git://github.com/ninja-ide/ninja-ide.git
 $ cd ninja-ide
-$ pip install requirements.txt
+$ pip install -r requirements.txt
 $ python ninja-ide.py
 ```
 


### PR DESCRIPTION
To install the dependencies written in a text file the `-r` flag must be passed to pip
- resolves <https://github.com/ninja-ide/ninja-ide/issues/2133>
- uses ignored PR <https://github.com/ninja-ide/ninja-ide/pull/2136>